### PR TITLE
JBIDE-24887 fix feature so it depends on license feature; fix root pom to depend on jbosstools parent pom

### DIFF
--- a/features/com.redhat.fabric8analytics.lsp.eclipse.feature/pom.xml
+++ b/features/com.redhat.fabric8analytics.lsp.eclipse.feature/pom.xml
@@ -3,11 +3,11 @@
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.redhat.bayesian.eclipse</groupId>
+		<groupId>com.redhat.fabric8analytics.eclipse</groupId>
 		<artifactId>features</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
-	<groupId>com.redhat.fabric8analytics.lsp.eclipse.features</groupId>
+	<groupId>com.redhat.fabric8analytics.eclipse</groupId>
 	<artifactId>com.redhat.fabric8analytics.lsp.eclipse.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -3,11 +3,11 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.redhat.bayesian.eclipse</groupId>
-		<artifactId>com.redhat.bayesian.parent</artifactId>
+		<groupId>com.redhat.fabric8analytics.eclipse</groupId>
+		<artifactId>com.redhat.fabric8analytics.parent</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
-	<groupId>com.redhat.bayesian.eclipse</groupId>
+	<groupId>com.redhat.fabric8analytics.eclipse</groupId>
 	<artifactId>features</artifactId>
 	
 	<name>plugins</name>	

--- a/plugins/com.redhat.fabric8analytics.lsp.eclipse/pom.xml
+++ b/plugins/com.redhat.fabric8analytics.lsp.eclipse/pom.xml
@@ -15,7 +15,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho-version}</version>
+				<version>${tychoVersion}</version>
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho-version}</version>
+				<version>${tychoVersion}</version>
 				<configuration>
 					<jgit.ignore>pom.xml,fabric8-analytics-lsp-server-test-devstudio/</jgit.ignore>
 				</configuration>

--- a/plugins/com.redhat.fabric8analytics.lsp.eclipse/pom.xml
+++ b/plugins/com.redhat.fabric8analytics.lsp.eclipse/pom.xml
@@ -19,18 +19,6 @@
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.0.0</version>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>fabric8-analytics-lsp-server-test-devstudio/</directory>
-						</fileset>
-					</filesets>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
 				<version>1.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jboss.tools</groupId>
+		<artifactId>parent</artifactId>
+		<version>4.5.1.AM1-SNAPSHOT</version>
+	</parent>
+
 	<groupId>com.redhat.fabric8analytics.eclipse</groupId>
 	<artifactId>com.redhat.fabric8analytics.parent</artifactId>
 	<packaging>pom</packaging>
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
-		<eclipseReleaseName>oxygen</eclipseReleaseName>
-		
-		<tycho-version>1.0.0</tycho-version>
-		<tychoExtrasVersion>${tycho-version}</tychoExtrasVersion>
-		<jbosstoolsRelengPublishVersion>4.5.1.Final</jbosstoolsRelengPublishVersion>
-
 		<oxygenURL>http://download.jboss.org/jbosstools/updates/requirements/oxygen/201706161000-Oxygen.0.RC4a/</oxygenURL>
 		<!-- <oxygenURL>http://download.eclipse.org/releases/oxygen/</oxygenURL> -->
 		<tycho.scmUrl>scm:git:https://github.com/fabric8-analytics/fabric8-analytics-devstudio-plugin.git</tycho.scmUrl>
-
-		<!-- if https://issues.jboss.org/browse/JBIDE-22248 comes back, use <jbossNexus>origin-repository.jboss.org</jbossNexus> -->
-		<jbossNexus>repository.jboss.org</jbossNexus>
-		<!-- https://issues.jboss.org/browse/JBIDE-23965 performance tuning for filemgmt.jboss.org - use IP as it's 3x faster (but subject to change) -->
-		<filemgmtJbossOrg>10.5.105.197</filemgmtJbossOrg>
-
-		<!-- default deployment settings to avoid dumping extra stuff in Nexus; override in site/pom.xml -->
-		<skipDeployToJBossOrg>true</skipDeployToJBossOrg>
-		<maven.deploy.skip>true</maven.deploy.skip>
-		<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
 	</properties>
 
 	<modules>
@@ -38,154 +28,32 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho-version}</version>
+				<version>${tychoVersion}</version>
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho-version}</version>
+				<version>${tychoVersion}</version>
 				<configuration>
-				<format>'v'yyyyMMdd-HHmm</format>
-				<timestampProvider>jgit</timestampProvider>
-				<jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
-				<jgit.ignore>pom.xml</jgit.ignore>
-				<archiveSite>true</archiveSite>
-				<environments>
-					<environment>
-					<os>macosx</os>
-					<ws>cocoa</ws>
-					<arch>x86</arch>
-					</environment>
-					<environment>
-					<os>macosx</os>
-					<ws>cocoa</ws>
-					<arch>x86_64</arch>
-					</environment>
-					<environment>
-					<os>win32</os>
-					<ws>win32</ws>
-					<arch>x86</arch>
-					</environment>
-					<environment>
-					<os>win32</os>
-					<ws>win32</ws>
-					<arch>x86_64</arch>
-					</environment>
-					<environment>
-					<os>linux</os>
-					<ws>gtk</ws>
-					<arch>x86</arch>
-					</environment>
-					<environment>
-					<os>linux</os>
-					<ws>gtk</ws>
-					<arch>x86_64</arch>
-					</environment>
-				</environments>
-				<sourceReferences>
-					 <generate>true</generate>
-				</sourceReferences>
+					<jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
 				</configuration>
-				<dependencies>
-				<dependency>
-					<groupId>org.eclipse.tycho.extras</groupId>
-					<artifactId>tycho-sourceref-jgit</artifactId>
-					<version>${tychoExtrasVersion}</version>
-				</dependency>
-				<dependency>
-					<groupId>org.eclipse.tycho.extras</groupId>
-					<artifactId>tycho-buildtimestamp-jgit</artifactId>
-					<version>${tychoExtrasVersion}</version>
-				</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
 
 	<repositories>
 		<repository>
+			<id>jbosstools-base</id>
+			<layout>p2</layout>
+			<url>${jbosstools-base-site}</url>
+		</repository>
+		<repository>
 			<id>oxygen</id>
 			<layout>p2</layout>
 			<url>${oxygenURL}</url>
 		</repository>
-
-		<repository>
-			<id>jboss-releases</id>
-			<name>JBoss Releases Maven Repository</name>
-			<url>https://${jbossNexus}/nexus/content/repositories/releases/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>jboss-snapshots-repository</id>
-			<name>JBoss Snapshots Repository</name>
-			<url>https://${jbossNexus}/nexus/content/repositories/snapshots/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>jboss-ga-repository</id>
-			<name>JBoss General Availability Maven Repository</name>
-			<url>http://maven.repository.redhat.com/ga/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</repository>
 	</repositories>
-
-	<!-- Additional m2 repos to resolve things like org.eclipse.tycho:tycho-maven-plugin -->
-	<!-- JBoss Nexus repos are also added, but in settings.xml -->
-	<pluginRepositories>
-		<pluginRepository>
-			<id>tycho-snapshots</id>
-			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>sonatype-public-grid</id>
-			<url>https://repository.sonatype.org/content/groups/sonatype-public-grid</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>sonatype-public-repository</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>jboss-snapshots-repository</id>
-			<name>JBoss Snapshots Repository</name>
-			<url>https://${jbossNexus}/nexus/content/repositories/snapshots/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>jboss-releases</id>
-			<name>JBoss Releases Maven Repository</name>
-			<url>https://${jbossNexus}/nexus/content/repositories/releases/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
-
-	<!-- To deploy parent to Nexus -->
-	<!--	Don't change "id" since it should match credentials entry in $M2_REPO/settings.xml -->
-	<distributionManagement>
-		<snapshotRepository>
-			<id>jboss-snapshots-repository</id>
-			<name>JBoss Snapshots Repository</name>
-			<url>https://${jbossNexus}/nexus/content/repositories/snapshots/</url>
-			<uniqueVersion>false</uniqueVersion>
-		</snapshotRepository>
-		<repository>
-			<id>jboss-releases-repository</id>
-			<name>JBoss Release Staging Repository</name>
-			<uniqueVersion>false</uniqueVersion>
-			<url>https://${jbossNexus}/nexus/service/local/staging/deploy/maven2/</url>
-			<layout>default</layout>
-		</repository>
-	</distributionManagement>
 
 	<scm>
 		<connection>scm:git:git://git@github.com:fabric8-analytics/fabric8-analytics-devstudio-plugin.git</connection>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -22,7 +22,7 @@
 			<plugin>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>target-platform-configuration</artifactId>
-			<version>${tycho-version}</version>
+			<version>${tychoVersion}</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -110,7 +110,7 @@
 
 	<!-- 
 		mvn verify -DBUILD_TIMESTAMP=2017-08-10_01-02-03 -DBUILD_NUMBER=314 \
-			-DJOB_NAME=com.redhat.bayesian.eclipse-site_master
+			-DJOB_NAME=jbosstools-fabric8analytics_master
 	-->
 
 </project>


### PR DESCRIPTION
remove maven-clean-plugin call to delete the fabric8-analytics-lsp-server-test-devstudio/ folder; instead we have all the important bits in .gitignore

Signed-off-by: nickboldt <nboldt@redhat.com>