### PR TITLE
remove org.eclipse.lsp4j and set minimum...

### DIFF
--- a/plugins/com.redhat.fabric8analytics.lsp.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/com.redhat.fabric8analytics.lsp.eclipse/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: com.redhat.fabric8analytics.lsp.eclipse;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: Red Hat Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.lsp4e;bundle-version="0.2.0",
- org.eclipse.lsp4j;bundle-version="0.2.0",
+Require-Bundle: org.eclipse.lsp4e;bundle-version="0.3.0",
  org.eclipse.ui,
  org.eclipse.swt,
  org.eclipse.core.runtime,


### PR DESCRIPTION
remove org.eclipse.lsp4j and set minimum version of org.eclipse.lsp4e to 0.3.0

Signed-off-by: nickboldt <nboldt@redhat.com>