### PR TITLE
Added skip=false to pom.xml

### DIFF
--- a/plugins/com.redhat.fabric8analytics.lsp.eclipse.ui/pom.xml
+++ b/plugins/com.redhat.fabric8analytics.lsp.eclipse.ui/pom.xml
@@ -20,7 +20,6 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
-				<version>1.3.0</version>
 				<executions>
 					<execution>
 						<id>fetch-grammar</id>
@@ -32,6 +31,7 @@
 							<url>https://github.com/invinciblejai/fabric8-analytics-lsp-server/archive/test-devstudio.zip</url>
 							<unpack>true</unpack>
 							<outputDirectory>${project.basedir}</outputDirectory>
+							<skip>false</skip>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
This variable is set in parent pom and can cause that the download of server's zip is skipped on Jenkins.