### PR TITLE
update to latest jbosstools parent pom...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.5.1.Final-SNAPSHOT</version>
+		<version>4.5.2.AM1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>com.redhat.fabric8analytics.eclipse</groupId>
@@ -12,7 +12,7 @@
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
-		<oxygenURL>http://download.jboss.org/jbosstools/updates/requirements/oxygen/201706161000-Oxygen.0.RC4a/</oxygenURL>
+		<oxygenURL>http://download.jboss.org/jbosstools/updates/requirements/oxygen/201710111001-Oxygen.1a/</oxygenURL>
 		<!-- <oxygenURL>http://download.eclipse.org/releases/oxygen/</oxygenURL> -->
 		<tycho.scmUrl>scm:git:https://github.com/fabric8-analytics/fabric8-analytics-devstudio-plugin.git</tycho.scmUrl>
 		<lsp4e-snapshot-site>http://download.eclipse.org/lsp4e/snapshots/</lsp4e-snapshot-site>


### PR DESCRIPTION
update to latest jbosstools parent pom 4.5.2.AM1; use latest Eclipse Oxygen.1a

Signed-off-by: nickboldt <nboldt@redhat.com>